### PR TITLE
Fix decoding attention FA2 and FA3

### DIFF
--- a/demo/attention_decode.py
+++ b/demo/attention_decode.py
@@ -1,8 +1,10 @@
 import math
+import time
 import torch
 import flashinfer
 import flash_attn
 import flash_attn_interface
+from cutedsl_kernels import DAttn2 as Attn, DAttnSplit1 as AttnSplit, AttnReduce1 as AttnReduce
 
 from profile_utils import ExperimentOutput, get_normal_bernoulli, get_attention_args
 
@@ -11,6 +13,22 @@ torch.manual_seed(18)
 BATCH = 1
 HEAD_DIM = 128
 CAUSAL = False
+
+CUTE_DSL_NSPLITS=4
+split_kernel = AttnSplit(
+    qk_mnk=(16, 128, 128),
+    stages=2,
+    p_stages=1,
+    k_splits=CUTE_DSL_NSPLITS,
+    )
+reduce_kernel = AttnReduce(n=128, splits=CUTE_DSL_NSPLITS)
+
+full_kernel = Attn(
+    qk_mnk=(16, 128, 128),
+    stages=2,
+    p_stages=1,
+    is_persistent=False,
+    )
 
 
 def naive_attention(q, k_cache, v_cache):
@@ -56,12 +74,14 @@ class FA2Baseline(AttentionBaseline):
 
 
 class FA2FlashDecodeBaseline(AttentionBaseline):
+    # DO NOT use other arguments. 
+    # Use the bare minimum arguments to get vanilla attention
     def __call__(self, q):
         return flash_attn.flash_attn_with_kvcache(
             q=q,
             k_cache=self.cache_K.unsqueeze(0),
             v_cache=self.cache_V.unsqueeze(0),
-            cache_seqlens=self.cache_K.shape[0],
+            # cache_seqlens=self.cache_K.shape[0],
             causal=CAUSAL,
         )
 
@@ -79,7 +99,7 @@ class FA3FlashDecodeBaseline(AttentionBaseline):
             q=q,
             k_cache=self.cache_K.unsqueeze(0),
             v_cache=self.cache_V.unsqueeze(0),
-            cache_seqlens=self.cache_K.shape[0],
+            # cache_seqlens=self.cache_K.shape[0],
             causal=CAUSAL,
         )
 
@@ -132,11 +152,11 @@ if __name__ == "__main__":
 
     pairs = []
     for name, cls in [
-        ("attn_torch_sdpa",      TorchSDPABaseline),
-        ("attn_flashinfer",      FlashInferBaseline),
-        ("attn_fa2",             FA2Baseline),
+        # ("attn_torch_sdpa",      TorchSDPABaseline),
+        # ("attn_flashinfer",      FlashInferBaseline),
+        # ("attn_fa2",             FA2Baseline),
         ("attn_fa2_flashdecode", FA2FlashDecodeBaseline),
-        ("attn_fa3",             FA3Baseline),
+        # ("attn_fa3",             FA3Baseline),
         ("attn_fa3_flashdecode", FA3FlashDecodeBaseline),
     ]:
         cK, cV = make_cache()
@@ -149,6 +169,7 @@ if __name__ == "__main__":
         out = ExperimentOutput(name, q_len, kv_len, nheads)
         out.run(baseline, tensors, ref)
         outputs.append(out)
+        time.sleep(2)
 
     if args.to_csv:
         for out in outputs:

--- a/demo/attention_decode.py
+++ b/demo/attention_decode.py
@@ -4,8 +4,6 @@ import torch
 import flashinfer
 import flash_attn
 import flash_attn_interface
-from cutedsl_kernels import DAttn2 as Attn, DAttnSplit1 as AttnSplit, AttnReduce1 as AttnReduce
-
 from profile_utils import ExperimentOutput, get_normal_bernoulli, get_attention_args
 
 torch.manual_seed(18)
@@ -13,22 +11,6 @@ torch.manual_seed(18)
 BATCH = 1
 HEAD_DIM = 128
 CAUSAL = False
-
-CUTE_DSL_NSPLITS=4
-split_kernel = AttnSplit(
-    qk_mnk=(16, 128, 128),
-    stages=2,
-    p_stages=1,
-    k_splits=CUTE_DSL_NSPLITS,
-    )
-reduce_kernel = AttnReduce(n=128, splits=CUTE_DSL_NSPLITS)
-
-full_kernel = Attn(
-    qk_mnk=(16, 128, 128),
-    stages=2,
-    p_stages=1,
-    is_persistent=False,
-    )
 
 
 def naive_attention(q, k_cache, v_cache):
@@ -152,11 +134,11 @@ if __name__ == "__main__":
 
     pairs = []
     for name, cls in [
-        # ("attn_torch_sdpa",      TorchSDPABaseline),
-        # ("attn_flashinfer",      FlashInferBaseline),
-        # ("attn_fa2",             FA2Baseline),
+        ("attn_torch_sdpa",      TorchSDPABaseline),
+        ("attn_flashinfer",      FlashInferBaseline),
+        ("attn_fa2",             FA2Baseline),
         ("attn_fa2_flashdecode", FA2FlashDecodeBaseline),
-        # ("attn_fa3",             FA3Baseline),
+        ("attn_fa3",             FA3Baseline),
         ("attn_fa3_flashdecode", FA3FlashDecodeBaseline),
     ]:
         cK, cV = make_cache()


### PR DESCRIPTION
new timings for seqlen 1024, 32 heads: 0.0215(FA2) and 0.0178(FA3)

where old timings were like 0.0237(FA2) and 0.0242(FA3)

I don't think we need to investigate what was causing this discrepancy, I think just adding other arguments was causing extra kernels to run in the background.
RMSEs are still the same, quite low

I also added a `time.sleep` in between runs