### PR TITLE
Adding triton persistent gemm, rmsnorm + linear. And helion gemm

### DIFF
--- a/.cache/helion/matmul_nt_1024_16384_2048_bfloat16.json
+++ b/.cache/helion/matmul_nt_1024_16384_2048_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    64,
+    64,
+    256
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_1024_32768_4096_bfloat16.json
+++ b/.cache/helion/matmul_nt_1024_32768_4096_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    64,
+    64,
+    256
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_1024_32768_4096_bfloat16_full.json
+++ b/.cache/helion/matmul_nt_1024_32768_4096_bfloat16_full.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    128,
+    256,
+    64
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    3
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    2
+  ],
+  "range_multi_buffers": [
+    null,
+    true
+  ],
+  "range_flattens": [
+    null,
+    false
+  ],
+  "load_eviction_policies": [
+    "first",
+    ""
+  ],
+  "num_warps": 8,
+  "num_stages": 4,
+  "indexing": [
+    "tensor_descriptor",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_1024_4096_16384_bfloat16.json
+++ b/.cache/helion/matmul_nt_1024_4096_16384_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    16,
+    16,
+    16
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_2048_2048_2048_bfloat16.json
+++ b/.cache/helion/matmul_nt_2048_2048_2048_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    256,
+    64,
+    64
+  ],
+  "loop_orders": [
+    [
+      1,
+      0
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    1
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    false
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_2048_2048_2048_bfloat16_full.json
+++ b/.cache/helion/matmul_nt_2048_2048_2048_bfloat16_full.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    128,
+    128,
+    64
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    "first"
+  ],
+  "num_warps": 4,
+  "num_stages": 2,
+  "indexing": [
+    "tensor_descriptor",
+    "tensor_descriptor",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_4096_1024_16384_bfloat16.json
+++ b/.cache/helion/matmul_nt_4096_1024_16384_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    16,
+    16,
+    16
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_4096_1024_4096_bfloat16.json
+++ b/.cache/helion/matmul_nt_4096_1024_4096_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    16,
+    16,
+    16
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_4096_1024_8192_bfloat16.json
+++ b/.cache/helion/matmul_nt_4096_1024_8192_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    16,
+    16,
+    16
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_4096_1536_7168_bfloat16.json
+++ b/.cache/helion/matmul_nt_4096_1536_7168_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    16,
+    16,
+    16
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_4096_4096_4096_bfloat16.json
+++ b/.cache/helion/matmul_nt_4096_4096_4096_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    16,
+    16,
+    16
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_4096_4096_4096_bfloat16_full.json
+++ b/.cache/helion/matmul_nt_4096_4096_4096_bfloat16_full.json
@@ -1,0 +1,48 @@
+{
+  "block_sizes": [
+    256,
+    128,
+    32
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    16
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    3,
+    1
+  ],
+  "range_multi_buffers": [
+    null,
+    true
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "last",
+    "first"
+  ],
+  "num_warps": 8,
+  "num_stages": 6,
+  "indexing": [
+    "tensor_descriptor",
+    "tensor_descriptor",
+    "tensor_descriptor"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "persistent_blocked",
+  "num_sm_multiplier": 1,
+  "maxnreg": 256
+}

--- a/.cache/helion/matmul_nt_8192_1024_2048_bfloat16.json
+++ b/.cache/helion/matmul_nt_8192_1024_2048_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    64,
+    64,
+    256
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/.cache/helion/matmul_nt_8192_2048_4096_bfloat16.json
+++ b/.cache/helion/matmul_nt_8192_2048_4096_bfloat16.json
@@ -1,0 +1,46 @@
+{
+  "block_sizes": [
+    16,
+    16,
+    16
+  ],
+  "loop_orders": [
+    [
+      0,
+      1
+    ]
+  ],
+  "l2_groupings": [
+    1
+  ],
+  "range_unroll_factors": [
+    0,
+    0
+  ],
+  "range_warp_specializes": [],
+  "range_num_stages": [
+    0,
+    0
+  ],
+  "range_multi_buffers": [
+    null,
+    null
+  ],
+  "range_flattens": [
+    null,
+    null
+  ],
+  "load_eviction_policies": [
+    "",
+    ""
+  ],
+  "num_warps": 4,
+  "num_stages": 1,
+  "indexing": [
+    "pointer",
+    "pointer",
+    "pointer"
+  ],
+  "atomic_indexing": [],
+  "pid_type": "flat"
+}

--- a/demo/helion_gemm_autotune.py
+++ b/demo/helion_gemm_autotune.py
@@ -1,0 +1,43 @@
+"""
+Autotunes the Helion GEMM and saves Configs to .cache/helion/
+
+How to run:
+python3 demo/helion_gemm_autotune.py                      # all shapes, quick
+python3 demo/helion_gemm_autotune.py --effort full        # all shapes, full
+python3 demo/helion_gemm_autotune.py --shape 3 --effort full   # one shape, full
+"""
+import argparse
+import os
+
+# Run each candidate in a subprocess so a crashing config doesn't kill the whole tuner
+os.environ.setdefault("HELION_AUTOTUNE_PRECOMPILE", "spawn")
+
+import torch
+from workload_shapes import GEMM_SHAPES
+from helion_gemm import autotune, cache_path
+
+torch.manual_seed(18)
+
+
+def tune_one(cfg, effort):
+    m, n, k = cfg["m"], cfg["n"], cfg["k"]
+    path = cache_path(m, n, k, torch.bfloat16, effort)
+    if os.path.exists(path):
+        print(f"Skipping {m}x{n}x{k} [{effort}] (exists)")
+        return
+    print(f"Autotuning {m}x{n}x{k} [{effort}] ...")
+    a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    saved = autotune(a, b, effort)
+    print(f"  Saved -> {saved}")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--shape", type=int, default=None,
+                   help="GEMM_SHAPES index to tune; omit to tune all shapes.")
+    p.add_argument("--effort", choices=["quick", "full"], default="quick")
+    args = p.parse_args()
+    shapes = [GEMM_SHAPES[args.shape]] if args.shape is not None else GEMM_SHAPES
+    for cfg in shapes:
+        tune_one(cfg, args.effort)

--- a/demo/new_profiling/gemm_new.py
+++ b/demo/new_profiling/gemm_new.py
@@ -4,6 +4,9 @@ from cutedsl_kernels import Gemm4SM90
 from workload_shapes import GEMM_ARGS_NT
 from profile_utils import ProfilingJob, get_profiling_job_args
 from cdsl_fn_utils import compile_cutedsl
+from triton_persistent_gemm import matmul as triton_matmul
+from triton_persistent_gemm import matmul_persistent as triton_matmul_persistent
+from helion_gemm import matmul as helion_matmul
 
 """
 Profiles torch gemm vs cutedsl gemm
@@ -42,9 +45,21 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "gemm",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel},
+        kernels={
+            "cutedsl": cdsl_kernel,
+            "torch": torch_kernel,
+            "triton": triton_matmul,
+            "triton_persistent": triton_matmul_persistent,
+            "helion": helion_matmul,
+        },
         args=prob_args,
-        arg_mask={"torch": (0, 1), "cutedsl": (0, 1)},
+        arg_mask={
+            "torch": (0, 1),
+            "cutedsl": (0, 1),
+            "triton": (0, 1),
+            "triton_persistent": (0, 1),
+            "helion": (0, 1),
+        },
         baseline="torch",
         ref="torch")
     

--- a/demo/new_profiling/rmsnorm_linear_new.py
+++ b/demo/new_profiling/rmsnorm_linear_new.py
@@ -6,7 +6,7 @@ from cdsl_fn_utils import make_fake_tensor, compile_cutedsl, STREAM
 from trt_utils import build_trt_runner
 from baselines.rmsnorm_swiglu_trt import RMSNormLinearModule
 from triton.testing import do_bench
-from triton_persistent_gemm import rmsnorm_linear_persistent
+from triton_rmsnorm_linear import rmsnorm_linear_persistent
 
 """
 RMSNorm + Linear
@@ -79,21 +79,9 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "rmsnorm_lin",
-        kernels={
-            "cutedsl": cdsl_kernel,
-            "torch": torch_kernel,
-            "trt": trt_runner,
-            "triton_persistent": rmsnorm_linear_persistent,
-            "max": torch_gemm,
-        },
+        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner, "triton_persistent": rmsnorm_linear_persistent, 'max': torch_gemm},
         args=prob_args,
-        arg_mask={
-            "torch": (0, 1, 3),
-            "cutedsl": (0, 1, 3),
-            "trt": (0, 1),
-            "triton_persistent": (0, 1, 3),
-            "max": (0, 1),
-        },
+        arg_mask={"torch": (0, 1, 3), "cutedsl": (0, 1, 3), "trt": (0, 1), "triton_persistent": (0, 1, 3), 'max': (0, 1)},
         baseline="torch",
         ref="torch")
     

--- a/demo/new_profiling/rmsnorm_linear_new.py
+++ b/demo/new_profiling/rmsnorm_linear_new.py
@@ -6,6 +6,7 @@ from cdsl_fn_utils import make_fake_tensor, compile_cutedsl, STREAM
 from trt_utils import build_trt_runner
 from baselines.rmsnorm_swiglu_trt import RMSNormLinearModule
 from triton.testing import do_bench
+from triton_persistent_gemm import rmsnorm_linear_persistent
 
 """
 RMSNorm + Linear
@@ -78,9 +79,21 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "rmsnorm_lin",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner, 'max': torch_gemm},
+        kernels={
+            "cutedsl": cdsl_kernel,
+            "torch": torch_kernel,
+            "trt": trt_runner,
+            "triton_persistent": rmsnorm_linear_persistent,
+            "max": torch_gemm,
+        },
         args=prob_args,
-        arg_mask={"torch": (0, 1, 3), "cutedsl": (0, 1, 3), "trt": (0, 1), 'max': (0, 1)},
+        arg_mask={
+            "torch": (0, 1, 3),
+            "cutedsl": (0, 1, 3),
+            "trt": (0, 1),
+            "triton_persistent": (0, 1, 3),
+            "max": (0, 1),
+        },
         baseline="torch",
         ref="torch")
     

--- a/demo/new_profiling/rmsnorm_linear_new.py
+++ b/demo/new_profiling/rmsnorm_linear_new.py
@@ -6,7 +6,7 @@ from cdsl_fn_utils import make_fake_tensor, compile_cutedsl, STREAM
 from trt_utils import build_trt_runner
 from baselines.rmsnorm_swiglu_trt import RMSNormLinearModule
 from triton.testing import do_bench
-from triton_rmsnorm_linear import rmsnorm_linear_persistent
+from triton_rmsnorm_linear import rmsnorm_linear_persistent, rmsnorm_linear_persistent_nn
 
 """
 RMSNorm + Linear
@@ -23,6 +23,25 @@ def torch_kernel(a: torch.Tensor, b: torch.Tensor, eps: float=EPS):
 @torch.compile
 def torch_gemm(a: torch.Tensor, b: torch.Tensor):
     return a @ b.t()
+
+# Caching to minimize timing of allocating mem for contiguous() and for creating .t() multiple times
+b_nn_transp_cache = {}
+b_nn_transp_contig_cache = {}
+
+def triton_nn_transp_kernel(a: torch.Tensor, b: torch.Tensor, eps: float=EPS):
+    # b.data_ptr is just a key for the cache
+    b_nn = b_nn_transp_cache.get(b.data_ptr())
+    if b_nn is None:
+        b_nn = b.t()
+        b_nn_transp_cache[b.data_ptr()] = b_nn
+    return rmsnorm_linear_persistent_nn(a, b_nn, eps)
+
+def triton_nn_transp_contig_kernel(a: torch.Tensor, b: torch.Tensor, eps: float=EPS):
+    b_nn = b_nn_transp_contig_cache.get(b.data_ptr())
+    if b_nn is None:
+        b_nn = b.t().contiguous()
+        b_nn_transp_contig_cache[b.data_ptr()] = b_nn
+    return rmsnorm_linear_persistent_nn(a, b_nn, eps)
 
 def get_cdsl_kernel(a, b, *args, **kwargs):
     m, k = a.shape
@@ -79,9 +98,25 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "rmsnorm_lin",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner, "triton_persistent": rmsnorm_linear_persistent, 'max': torch_gemm},
+        kernels={
+            "cutedsl": cdsl_kernel,
+            "torch": torch_kernel,
+            "trt": trt_runner,
+            "triton_persistent_nt": rmsnorm_linear_persistent,
+            "triton_persistent_nn_transp": triton_nn_transp_kernel,
+            "triton_persistent_nn_transp_contig": triton_nn_transp_contig_kernel,
+            "max": torch_gemm,
+        },
         args=prob_args,
-        arg_mask={"torch": (0, 1, 3), "cutedsl": (0, 1, 3), "trt": (0, 1), "triton_persistent": (0, 1, 3), 'max': (0, 1)},
+        arg_mask={
+            "torch": (0, 1, 3),
+            "cutedsl": (0, 1, 3),
+            "trt": (0, 1),
+            "triton_persistent_nt": (0, 1, 3),
+            "triton_persistent_nn_transp": (0, 1, 3),
+            "triton_persistent_nn_transp_contig": (0, 1, 3),
+            "max": (0, 1),
+        },
         baseline="torch",
         ref="torch")
     

--- a/python/helion_gemm.py
+++ b/python/helion_gemm.py
@@ -1,0 +1,83 @@
+import os
+import torch
+import helion
+from helion import Config
+import helion.language as hl
+
+
+CACHE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".cache", "helion"
+)
+
+_kernel_cache = {}
+
+
+def config_key(m, n, k, dtype, effort="quick"):
+    # Naming scheme: quick by default, full if full effort
+    base = f"matmul_nt_{m}_{n}_{k}_{str(dtype).split('.')[-1]}"
+    return base if effort == "quick" else f"{base}_{effort}"
+
+
+def cache_path(m, n, k, dtype, effort="quick"):
+    return os.path.join(CACHE_DIR, f"{config_key(m, n, k, dtype, effort)}.json")
+
+
+def _matmul_nt_fn(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    m, k = a.size()
+    n, _ = b.size()
+    out = torch.empty([m, n], dtype=a.dtype, device=a.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, a[tile_m, tile_k], b[tile_n, tile_k].T)
+        out[tile_m, tile_n] = acc.to(a.dtype)
+    return out
+
+
+def autotune(a: torch.Tensor, b: torch.Tensor, effort: str = "quick") -> str:
+    """Autotune at the specified effort and save the Config to .cache/helion/
+    """
+    m, k = a.shape
+    n = b.shape[0]
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    path = cache_path(m, n, k, a.dtype, effort)
+    tuner = helion.kernel(static_shapes=True, autotune_effort=effort)(_matmul_nt_fn)
+    best = tuner.autotune((a, b))
+    best.save(path)
+    return path
+
+
+def _resolve_path(m, n, k, dtype, effort):
+    # quick/full effort -> use that exact file
+    # None -> prefer full if it exists, else quick
+    if effort in ("quick", "full"):
+        return cache_path(m, n, k, dtype, effort)
+    full = cache_path(m, n, k, dtype, "full")
+    return full if os.path.exists(full) else cache_path(m, n, k, dtype, "quick")
+
+
+def _get_kernel(a: torch.Tensor, b: torch.Tensor, effort=None):
+    m, k = a.shape
+    n = b.shape[0]
+    path = _resolve_path(m, n, k, a.dtype, effort)
+    if path not in _kernel_cache:
+        if not os.path.exists(path):
+            raise FileNotFoundError(
+                f"No Helion config at {path}. "
+            )
+        _kernel_cache[path] = helion.kernel(config=Config.load(path), static_shapes=True)(_matmul_nt_fn)
+    return _kernel_cache[path]
+
+
+def matmul(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Computes a @ b.T for a=(m, k), b=(n, k). Loads a pre-tuned Config, does not autotune
+
+    Which config: HELION_GEMM_EFFORT=quick|full forces that effort
+    if none specified then defaults to full, fall back on quick
+    """
+    assert a.ndim == 2 and b.ndim == 2, "Expected two matrices"
+    assert a.is_cuda and b.is_cuda, "Expected CUDA tensors"
+    assert a.shape[1] == b.shape[1], "Incompatible reduction dimensions"
+    assert a.dtype == b.dtype, "Input dtypes must match"
+    effort = os.environ.get("HELION_GEMM_EFFORT")  # 'quick', 'full', or None (auto)
+    return _get_kernel(a, b, effort)(a, b)

--- a/python/profile_utils.py
+++ b/python/profile_utils.py
@@ -355,6 +355,12 @@ class ProfilingJob:
         self.args = {k: args.tensors(arg_mask.get(k, None)) for k in kernels}
         self.ref = self.kernels[ref](*args.tensors_64(arg_mask.get(ref, None)))
         self.outputs = {k: ExperimentOutput(f'{label}:{args._populated_idx}:{k}') for k in kernels}
+
+        m, n, k = args.arg('m', 'n', 'k')
+        self.outputs = {
+            name: ExperimentOutput(f'{label}:{args._populated_idx}:{name}', m=m, n=n, k=k)
+            for name in kernels
+        }
     
     def _run(self):
         for k in self.kernels:

--- a/python/triton_persistent_gemm.py
+++ b/python/triton_persistent_gemm.py
@@ -1,0 +1,197 @@
+"""
+Persistent matmul in NT layout (C = A @ B.T). A=(M,K), B=(N,K)
+"""
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+def matmul_get_configs():
+    return [
+        triton.Config(
+            {"BLOCK_SIZE_M": BM, "BLOCK_SIZE_N": BN, "BLOCK_SIZE_K": BK, "GROUP_SIZE_M": 8},
+            num_stages=s, num_warps=w)
+        for BM in [128]
+        for BN in [128, 256]
+        for BK in [64, 128]
+        for s in [2, 3, 4]
+        for w in [4, 8]
+    ]
+
+
+def matmul_tma_persistent_get_configs():
+    return [
+        triton.Config(
+            {"BLOCK_SIZE_M": BM, "BLOCK_SIZE_N": BN, "BLOCK_SIZE_K": BK, "GROUP_SIZE_M": 8,
+             "EPILOGUE_SUBTILE": SUBTILE},
+            num_stages=s, num_warps=w)
+        for BM in [128]
+        for BN in [128, 256]
+        for BK in [64, 128]
+        for s in [2, 3, 4]
+        for w in [4, 8]
+        for SUBTILE in [True, False]
+    ]
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (tile_id % group_size_m)
+    pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@triton.autotune(configs=matmul_get_configs(), key=["M", "N", "K"])
+@triton.jit
+def matmul_kernel(
+    a_ptr, b_ptr, c_ptr,
+    M, N, K,
+    stride_am, stride_ak,
+    stride_bn, stride_bk,
+    stride_cm, stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    pid_m, pid_n = _compute_pid(pid, num_pid_in_group, num_pid_m, GROUP_SIZE_M, 0)
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    safe_offs_m = tl.max_contiguous(tl.multiple_of(offs_m % M, BLOCK_SIZE_M), BLOCK_SIZE_M)
+    safe_offs_n = tl.max_contiguous(tl.multiple_of(offs_n % N, BLOCK_SIZE_N), BLOCK_SIZE_N)
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    a_ptrs = a_ptr + safe_offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + safe_offs_n[None, :] * stride_bn + offs_k[:, None] * stride_bk
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for ki in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - ki * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < k_remaining, other=0.0)
+        accumulator = tl.dot(a, b, accumulator)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=c_mask)
+
+
+@triton.autotune(configs=matmul_tma_persistent_get_configs(), key=["M", "N", "K"])
+@triton.jit
+def matmul_kernel_descriptor_persistent(
+    a_ptr, b_ptr, c_ptr,
+    M, N, K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    dtype = c_ptr.dtype.element_ty
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    a_desc = tl.make_tensor_descriptor(a_ptr, shape=[M, K], strides=[K, 1],
+                                       block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = tl.make_tensor_descriptor(b_ptr, shape=[N, K], strides=[K, 1],
+                                       block_shape=[BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = tl.make_tensor_descriptor(c_ptr, shape=[M, N], strides=[N, 1],
+                                       block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N if not EPILOGUE_SUBTILE else BLOCK_SIZE_N // 2])
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m, pid_n = _compute_pid(tile_id_c, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_cm = pid_m * BLOCK_SIZE_M
+        offs_cn = pid_n * BLOCK_SIZE_N
+
+        if EPILOGUE_SUBTILE:
+            acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+            acc = tl.permute(acc, (0, 2, 1))
+            acc0, acc1 = tl.split(acc)
+            c0 = acc0.to(dtype)
+            c_desc.store([offs_cm, offs_cn], c0)
+            c1 = acc1.to(dtype)
+            c_desc.store([offs_cm, offs_cn + BLOCK_SIZE_N // 2], c1)
+        else:
+            c = accumulator.to(dtype)
+            c_desc.store([offs_cm, offs_cn], c)
+
+
+def _validate_inputs(a: torch.Tensor, b: torch.Tensor):
+    assert a.ndim == 2 and b.ndim == 2, "Expected two matrices"
+    assert a.is_cuda and b.is_cuda, "Expected CUDA tensors"
+    assert a.shape[1] == b.shape[1], "Incompatible reduction dimensions"
+    assert a.dtype == b.dtype, "Input dtypes must match"
+
+
+def matmul(a: torch.Tensor, b: torch.Tensor):
+    _validate_inputs(a, b)
+    M, K = a.shape
+    N = b.shape[0]
+    c = torch.empty((a.shape[0], b.shape[0]), dtype=a.dtype, device=a.device)
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(N, meta["BLOCK_SIZE_N"]),
+    )
+    matmul_kernel[grid](
+        a, b, c,
+        M, N, K,
+        a.stride(0), a.stride(1),
+        b.stride(0), b.stride(1),
+        c.stride(0), c.stride(1),
+    )
+    return c
+
+
+def matmul_persistent(a: torch.Tensor, b: torch.Tensor):
+    _validate_inputs(a, b)
+    M, K = a.shape
+    N = b.shape[0]
+    c = _output(a, b)
+
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    grid = lambda META: (
+        min(num_sms, triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"])),
+    )
+    matmul_kernel_descriptor_persistent[grid](
+        a, b, c,
+        M, N, K,
+        NUM_SMS=num_sms,
+    )
+    return c

--- a/python/triton_rmsnorm_linear.py
+++ b/python/triton_rmsnorm_linear.py
@@ -9,7 +9,6 @@ from triton_persistent_gemm import (
     matmul_get_configs,
     _compute_pid,
     _validate_inputs,
-    _output,
 )
 
 
@@ -70,7 +69,7 @@ def rmsnorm_linear_persistent(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-
     _validate_inputs(a, b)
     M, K = a.shape
     N = b.shape[0]
-    c = _output(a, b)
+    c = torch.empty((a.shape[0], b.shape[0]), dtype=a.dtype, device=a.device)
     num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
     grid = lambda META: (
         min(num_sms, triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"])),

--- a/python/triton_rmsnorm_linear.py
+++ b/python/triton_rmsnorm_linear.py
@@ -1,0 +1,87 @@
+"""
+Fused RMSNorm-linear in NT layout: C = RMSNorm(A) @ B.T, with A=(M,K), B=(N,K)
+"""
+import torch
+import triton
+import triton.language as tl
+
+from triton_persistent_gemm import (
+    matmul_get_configs,
+    _compute_pid,
+    _validate_inputs,
+    _output,
+)
+
+
+@triton.autotune(configs=matmul_get_configs(), key=["M", "N", "K"])
+@triton.jit
+def rmsnorm_linear_kernel(
+    a_ptr, b_ptr, c_ptr,
+    M, N, K,
+    eps,
+    stride_am, stride_ak,
+    stride_bn, stride_bk,
+    stride_cm, stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_tiles = num_pid_m * num_pid_n
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    offs_k_mask = tl.arange(0, BLOCK_SIZE_K)
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        safe_offs_m = tl.max_contiguous(tl.multiple_of(offs_m % M, BLOCK_SIZE_M), BLOCK_SIZE_M)
+        safe_offs_n = tl.max_contiguous(tl.multiple_of(offs_n % N, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        # row_sumsq only depends on pid_m, so it is recomputed in every N-tile of this row
+        row_sumsq = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+        for ki in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            offs_k = ki * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+            a_ptrs = a_ptr + safe_offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+            b_ptrs = b_ptr + safe_offs_n[None, :] * stride_bn + offs_k[:, None] * stride_bk
+            k_remaining = K - ki * BLOCK_SIZE_K
+            a = tl.load(a_ptrs, mask=offs_k_mask[None, :] < k_remaining, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k_mask[:, None] < k_remaining, other=0.0)
+            accumulator = tl.dot(a, b, accumulator)
+            a_f32 = a.to(tl.float32)
+            row_sumsq += tl.sum(a_f32 * a_f32, axis=1)
+
+        inv_rms = tl.rsqrt(row_sumsq / K + eps)
+        accumulator *= inv_rms[:, None]
+
+        offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_ptrs = c_ptr + offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn
+        c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+        tl.store(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=c_mask)
+
+
+def rmsnorm_linear_persistent(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-5):
+    _validate_inputs(a, b)
+    M, K = a.shape
+    N = b.shape[0]
+    c = _output(a, b)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    grid = lambda META: (
+        min(num_sms, triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"])),
+    )
+    rmsnorm_linear_kernel[grid](
+        a, b, c,
+        M, N, K,
+        eps,
+        a.stride(0), a.stride(1),
+        b.stride(0), b.stride(1),
+        c.stride(0), c.stride(1),
+        NUM_SMS=num_sms,
+    )
+    return c

--- a/python/triton_rmsnorm_linear.py
+++ b/python/triton_rmsnorm_linear.py
@@ -1,6 +1,3 @@
-"""
-Fused RMSNorm-linear in NT layout: C = RMSNorm(A) @ B.T, with A=(M,K), B=(N,K)
-"""
 import torch
 import triton
 import triton.language as tl
@@ -42,7 +39,6 @@ def rmsnorm_linear_kernel(
         safe_offs_n = tl.max_contiguous(tl.multiple_of(offs_n % N, BLOCK_SIZE_N), BLOCK_SIZE_N)
 
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-        # row_sumsq only depends on pid_m, so it is recomputed in every N-tile of this row
         row_sumsq = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
         for ki in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
             offs_k = ki * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
@@ -80,6 +76,29 @@ def rmsnorm_linear_persistent(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-
         eps,
         a.stride(0), a.stride(1),
         b.stride(0), b.stride(1),
+        c.stride(0), c.stride(1),
+        NUM_SMS=num_sms,
+    )
+    return c
+
+
+def rmsnorm_linear_persistent_nn(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-5):
+    # a=(M,K), b=(K,N), C = RMSNorm(a) @ b
+    assert a.ndim == 2 and b.ndim == 2 and a.is_cuda and b.is_cuda
+    assert a.shape[1] == b.shape[0], "K mismatch, b must be (K, N) for NN"
+    M, K = a.shape
+    N = b.shape[1]
+    c = torch.empty((M, N), dtype=a.dtype, device=a.device)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    grid = lambda META: (
+        min(num_sms, triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"])),
+    )
+    rmsnorm_linear_kernel[grid](
+        a, b, c,
+        M, N, K,
+        eps,
+        a.stride(0), a.stride(1),
+        b.stride(1), b.stride(0), # Swap strides here. First is stride_bn, then stride_bk
         c.stride(0), c.stride(1),
         NUM_SMS=num_sms,
     )


### PR DESCRIPTION
**Note about this draft PR:**

Helion autotune is now refactored differently. 

However, triton persistent rmsnorm linear example here seems to have a compiler issue related to https://github.com/triton-lang/triton/issues/8259

(To debug look at the IR at stages of the pipeline). The accuracy issue for this one was resolved with adding `tl.debug_barrier`. It is possible that other RMSNorm + linear triton kernels also miscompile, especially if they look very slow. Good to check pipeline logic in IR.

---
Previous PR summary:


I added the helion configurations from autotuning because it can take ~2h for a full autotune for a shape and might be useful to rerun. That is why marked as draft for now.

By default the configurations are for error level quick, unless have appended `_full.json`.

Timing results with Helion and persistent Triton (with TMA) below. Autotuned full exists for the smallest square shapes, 4096 x 4096 x 4096 and the largest shape to be representative comparison. All are as a comparison to the baseline of torch (cuBLAS).

<img width="2400" height="1050" alt="gemm_quick_vs_full" src="https://github.com/user-attachments/assets/60c8b652-8b62-410e-afb3-2234958a1f6b" />


