### PR TITLE
Benchmark C2 gemm in kernel benchmarking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,7 @@
 [submodule "third_party/flash_attention"]
 	path = third_party/flash_attention
 	url = https://github.com/Dao-AILab/flash-attention.git
+[submodule "third_party/compiler_2"]
+	path = third_party/compiler_2
+	url = https://github.com/dungwoong/compiler_2.git
+	branch = lower_candidates

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,4 @@
 [submodule "third_party/compiler_2"]
 	path = third_party/compiler_2
 	url = https://github.com/dungwoong/compiler_2.git
-	branch = lower_candidates
+	branch = kernel_demo_redo

--- a/add_path.sh
+++ b/add_path.sh
@@ -2,5 +2,6 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [ -f "$REPO_ROOT/.venv/bin/activate" ] && source "$REPO_ROOT/.venv/bin/activate"
 export PYTHONPATH="$PYTHONPATH:$REPO_ROOT/python:$REPO_ROOT/third_party/fused_kernels_cutedsl_lib/python:$REPO_ROOT/third_party/cublas_gemm/python:$REPO_ROOT/third_party/helion_kernels_lib/python:$REPO_ROOT/third_party/compiler_2/python"
 export TORCH_CUDA_ARCH_LIST="9.0" # for torch extensions
+export C2_CACHE_DIR="$REPO_ROOT/.cache/c2" 
 export CUDA_HOME=/usr/local/cuda # override host module-system path to container's CUDA 12.9
 unset REQUESTS_CA_BUNDLE CURL_CA_BUNDLE SSL_CERT_FILE PIP_CERT # host CA paths don't exist in Ubuntu container

--- a/add_path.sh
+++ b/add_path.sh
@@ -1,6 +1,6 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [ -f "$REPO_ROOT/.venv/bin/activate" ] && source "$REPO_ROOT/.venv/bin/activate"
-export PYTHONPATH="$PYTHONPATH:$REPO_ROOT/python:$REPO_ROOT/third_party/fused_kernels_cutedsl_lib/python:$REPO_ROOT/third_party/cublas_gemm/python:$REPO_ROOT/third_party/helion_kernels_lib/python"
+export PYTHONPATH="$PYTHONPATH:$REPO_ROOT/python:$REPO_ROOT/third_party/fused_kernels_cutedsl_lib/python:$REPO_ROOT/third_party/cublas_gemm/python:$REPO_ROOT/third_party/helion_kernels_lib/python:$REPO_ROOT/third_party/compiler_2/python"
 export TORCH_CUDA_ARCH_LIST="9.0" # for torch extensions
 export CUDA_HOME=/usr/local/cuda # override host module-system path to container's CUDA 12.9
 unset REQUESTS_CA_BUNDLE CURL_CA_BUNDLE SSL_CERT_FILE PIP_CERT # host CA paths don't exist in Ubuntu container

--- a/demo/attention_decode.py
+++ b/demo/attention_decode.py
@@ -6,6 +6,7 @@ import flash_attn_interface
 from profile_utils import ExperimentOutput, get_normal_bernoulli, get_attention_args
 from cutedsl_kernels import DAttn2, DAttnSplit1, AttnReduce1
 from cdsl_helpers.cdsl_fn_utils import compile_cutedsl
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
 torch.manual_seed(18)
 
@@ -45,6 +46,14 @@ class FlashInferBaseline(AttentionBaseline):
             kv_layout="NHD",
             causal=CAUSAL,
         )
+        # This does not work since flashinfer expects 1 new token ONLY, but this is decoding attention
+        # out = flashinfer.single_decode_with_kv_cache(
+        #     q = q.squeeze(0).squeeze(0),
+        #     k = self.cache_K,
+        #     v = self.cache_V,
+        #     kv_layout="NHD",
+        #     # causal=CAUSAL,
+        # )
         return out.unsqueeze(0)
 
 
@@ -186,13 +195,16 @@ if __name__ == "__main__":
             baseline = baseline.with_kernel(compiled_attn_splitk, compiled_attn_reduce)
         pairs.append((name, baseline))
 
-    tensors = (q,)
-    outputs = []
-    for name, baseline in pairs:
-        out = ExperimentOutput(name, q_len, kv_len, nheads)
-        out.run(baseline, tensors, ref)
-        outputs.append(out)
-        time.sleep(2)
+    
+    # CuDNN seems to work fine in the decoding case, so we can make torch sdpa use cudnn
+    with sdpa_kernel([SDPBackend.CUDNN_ATTENTION]):
+        tensors = (q,)
+        outputs = []
+        for name, baseline in pairs:
+            out = ExperimentOutput(name, q_len, kv_len, nheads)
+            out.run(baseline, tensors, ref)
+            outputs.append(out)
+            time.sleep(2)
 
     if args.to_csv:
         for out in outputs:

--- a/demo/new_profiling/gemm_new.py
+++ b/demo/new_profiling/gemm_new.py
@@ -5,12 +5,7 @@ from workload_shapes import GEMM_ARGS_NT
 from profile_utils import ProfilingJob, get_profiling_job_args
 from cdsl_fn_utils import compile_cutedsl
 
-from c2.hl.nodes import Builder, ForLoop, PersistentForLoopSM90
-import c2.hl.user_nodes
-from c2.hl.util import DType
-import hlgraph.nodes as hlN
-from hel import nodes
-from hlgraph.rasterization_helper import PersistentRasterizationHelper
+from kernels.hel.gemm import get_kernel as get_c2_kernel
 from compiler import compile_hel
 
 """
@@ -38,28 +33,6 @@ gemm = Gemm4SM90(
 )
 
 
-def build_c2_gemm(m, n, k):
-    """See compiler_2's python/kernels/hel/gemm.py."""
-    raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
-    builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
-    gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
-    gB = builder.GlobalTensor['b', DType.bfloat16, (n, k)]()
-    gC = builder.GlobalTensor['c', DType.bfloat16, (m, n)]()
-
-    with builder.enter_scope(PersistentForLoopSM90('sched_idx', raster.total_tiles(), raster.total_blocks(), block_dim=raster.block_dim())) as sched_idx:
-        coords = builder.ScheduleFunction['sched_coord', *raster.layout()](sched_idx)
-        tm = builder.SliceCoord[0](coords)
-        tn = builder.SliceCoord[1](coords)
-        acc = builder.hel_Zeros['acc', C2_TILE_M, C2_TILE_N, DType.float32]()
-        with builder.enter_scope(ForLoop('k', 0, k // C2_TILE_K, 1)) as tk:
-            dA = builder.hel_Load['dA', C2_TILE_M, C2_TILE_K](gA, tm, tk)
-            dB = builder.hel_Load['dB', C2_TILE_N, C2_TILE_K](gB, tn, tk)
-            builder.hel_AccumulatingGemm(dA, dB, acc)
-        builder.hel_Store(acc, gC, tm, tn)
-
-    return builder
-
-
 if __name__ == "__main__":
     args = get_profiling_job_args()
     prob_args = GEMM_ARGS_NT.with_config(args.config) # Get set of tensors defining the problem
@@ -68,7 +41,7 @@ if __name__ == "__main__":
     compiled_gemm = compile_cutedsl(prob_args.tensors(), gemm, include_stream=False)
 
     m, n, k = prob_args.arg('m', 'n', 'k')
-    c2_kernel = compile_hel(build_c2_gemm(m, n, k), name=f'gemm_{m}x{n}x{k}')
+    c2_kernel = compile_hel(get_c2_kernel(m, n, k, C2_TILE_M, C2_TILE_N, C2_TILE_K), name=f'gemm_{m}x{n}x{k}')
 
     def cdsl_kernel(a_: torch.Tensor, b_: torch.Tensor):
         o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')

--- a/demo/new_profiling/gemm_new.py
+++ b/demo/new_profiling/gemm_new.py
@@ -5,12 +5,22 @@ from workload_shapes import GEMM_ARGS_NT
 from profile_utils import ProfilingJob, get_profiling_job_args
 from cdsl_fn_utils import compile_cutedsl
 
+from c2.hl.nodes import Builder, ForLoop, PersistentForLoopSM90
+import c2.hl.user_nodes
+from c2.hl.util import DType
+import hlgraph.nodes as hlN
+from hel import nodes
+from hlgraph.rasterization_helper import PersistentRasterizationHelper
+from compiler import compile_hel
+
 """
-Profiles torch gemm vs cutedsl gemm
+Profiles torch gemm vs cutedsl gemm vs compiler_2's autotuned gemm
 
 Uses new profiling setup
 """
 torch.manual_seed(18)
+
+C2_TILE_M, C2_TILE_N, C2_TILE_K = 128, 256, 64
 
 @torch.compile
 def torch_kernel(a: torch.Tensor, b: torch.Tensor):
@@ -28,6 +38,28 @@ gemm = Gemm4SM90(
 )
 
 
+def build_c2_gemm(m, n, k):
+    """See compiler_2's demo/hel/hel_gemm_2.py."""
+    raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
+    builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
+    gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
+    gB = builder.GlobalTensor['b', DType.bfloat16, (n, k)]()
+    gC = builder.GlobalTensor['c', DType.bfloat16, (m, n)]()
+
+    with builder.enter_scope(PersistentForLoopSM90('sched_idx', raster.total_tiles(), raster.total_blocks(), block_dim=raster.block_dim())) as sched_idx:
+        coords = builder.ScheduleFunction['sched_coord', *raster.layout()](sched_idx)
+        tm = builder.SliceCoord[0](coords)
+        tn = builder.SliceCoord[1](coords)
+        acc = builder.hel_Zeros['acc', C2_TILE_M, C2_TILE_N, DType.float32]()
+        with builder.enter_scope(ForLoop('k', 0, k // C2_TILE_K, 1)) as tk:
+            dA = builder.hel_Load['dA', C2_TILE_M, C2_TILE_K](gA, tm, tk)
+            dB = builder.hel_Load['dB', C2_TILE_N, C2_TILE_K](gB, tn, tk)
+            builder.hel_AccumulatingGemm(dA, dB, acc)
+        builder.hel_Store(acc, gC, tm, tn)
+
+    return builder
+
+
 if __name__ == "__main__":
     args = get_profiling_job_args()
     prob_args = GEMM_ARGS_NT.with_config(args.config) # Get set of tensors defining the problem
@@ -35,17 +67,25 @@ if __name__ == "__main__":
     # Compile CuteDSL manually
     compiled_gemm = compile_cutedsl(prob_args.tensors(), gemm, include_stream=False)
 
+    m, n, k = prob_args.arg('m', 'n', 'k')
+    c2_kernel = compile_hel(build_c2_gemm(m, n, k), name=f'gemm_{m}x{n}x{k}')
+
     def cdsl_kernel(a_: torch.Tensor, b_: torch.Tensor):
         o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')
         compiled_gemm(a_, b_, o)
         return o
 
+    def c2_kernel_fn(a_: torch.Tensor, b_: torch.Tensor):
+        o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')
+        c2_kernel(a_, b_, o)
+        return o
+
     p = ProfilingJob(
         "gemm",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel},
+        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, "c2": c2_kernel_fn},
         args=prob_args,
-        arg_mask={"torch": (0, 1), "cutedsl": (0, 1)},
+        arg_mask={"torch": (0, 1), "cutedsl": (0, 1), "c2": (0, 1)},
         baseline="torch",
         ref="torch")
-    
+
     p.run(ncu=args.ncu)

--- a/demo/new_profiling/gemm_new.py
+++ b/demo/new_profiling/gemm_new.py
@@ -39,7 +39,7 @@ gemm = Gemm4SM90(
 
 
 def build_c2_gemm(m, n, k):
-    """See compiler_2's demo/hel/hel_gemm_2.py."""
+    """See compiler_2's python/kernels/hel/gemm.py."""
     raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
     builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
     gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
@@ -88,4 +88,4 @@ if __name__ == "__main__":
         baseline="torch",
         ref="torch")
 
-    p.run(ncu=args.ncu)
+    p.run(ncu=args.ncu, csv=args.csv)

--- a/demo/new_profiling/lora_new.py
+++ b/demo/new_profiling/lora_new.py
@@ -7,10 +7,21 @@ from cdsl_fn_utils import compile_cutedsl
 from trt_utils import build_trt_runner
 from baselines.lora import LoraModule
 
+from c2.hl.nodes import Builder, ForLoop, PersistentForLoopSM90, ConstantExpr
+import c2.hl.user_nodes
+from c2.hl.util import DType
+import hlgraph.nodes as hlN
+from hel import nodes
+from hlgraph.rasterization_helper import PersistentRasterizationHelper
+from compiler import compile_hel
+
 """
 LoRA, uses lora_dim=16
 """
 torch.manual_seed(18)
+
+LORA_DIM = 16
+C2_TILE_M, C2_TILE_N, C2_TILE_K = 128, 256, 64
 
 @torch.compile
 def torch_kernel(a: torch.Tensor, b: torch.Tensor, lA: torch.Tensor, lB: torch.Tensor):
@@ -25,6 +36,37 @@ gemm = LoRASM90(
     ab_stage=3,
     reuse_ab=True,
     is_persistent=False)
+
+
+def build_c2_lora(m, n, k):
+    """See compiler_2's python/kernels/hel/lora.py.
+    """
+    raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
+    builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
+    
+    gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
+    gB = builder.GlobalTensor['b', DType.bfloat16, (n, k)]()
+    gXA = builder.GlobalTensor['xa', DType.bfloat16, (m, LORA_DIM)]()
+    gLB = builder.GlobalTensor['lora_b', DType.bfloat16, (n, LORA_DIM)]()
+    gC = builder.GlobalTensor['c', DType.bfloat16, (m, n)]()
+
+    with builder.enter_scope(PersistentForLoopSM90('sched_idx', raster.total_tiles(), raster.total_blocks(), block_dim=raster.block_dim())) as sched_idx:
+        coords = builder.ScheduleFunction['sched_coord', *raster.layout()](sched_idx)
+        tm = builder.SliceCoord[0](coords)
+        tn = builder.SliceCoord[1](coords)
+        acc = builder.hel_Zeros['acc', C2_TILE_M, C2_TILE_N, DType.float32]()
+        with builder.enter_scope(ForLoop('k', 0, k // C2_TILE_K, 1)) as tk:
+            dA = builder.hel_Load['dA', C2_TILE_M, C2_TILE_K](gA, tm, tk)
+            dB = builder.hel_Load['dB', C2_TILE_N, C2_TILE_K](gB, tn, tk)
+            builder.hel_AccumulatingGemm(dA, dB, acc)
+        # the lora update is a single k step, so it sits outside the k loop
+        dxA = builder.hel_Load['dxA', C2_TILE_M, LORA_DIM](gXA, tm, ConstantExpr(0))
+        dlB = builder.hel_Load['dLB', C2_TILE_N, LORA_DIM](gLB, tn, ConstantExpr(0))
+        builder.hel_AccumulatingGemm(dxA, dlB, acc)
+        builder.hel_Store(acc, gC, tm, tn)
+
+    return builder
+
 
 if __name__ == "__main__":
     args = get_profiling_job_args()
@@ -43,6 +85,14 @@ if __name__ == "__main__":
         return o
     
     m, n, k = prob_args.arg('m', 'n', 'k')
+    c2_kernel = compile_hel(build_c2_lora(m, n, k), name=f'lora_{m}x{n}x{k}')
+
+    def c2_kernel_fn(a_: torch.Tensor, b_: torch.Tensor, lA_: torch.Tensor, lB_: torch.Tensor):
+        o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')
+        lxa = a_ @ lA_.t()
+        c2_kernel(a_, b_, lxa, lB_, o)
+        return o
+
     trt_runner = build_trt_runner(
         module=LoraModule(),
         example_inputs=prob_args.tensors((0, 1, 2, 3)),
@@ -53,10 +103,10 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "lora",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner},
+        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner, 'c2': c2_kernel_fn},
         args=prob_args,
-        arg_mask={"torch": (0, 1, 2, 3), "cutedsl": (0, 1, 2, 3)},
+        arg_mask={"torch": (0, 1, 2, 3), "cutedsl": (0, 1, 2, 3), 'c2': (0, 1, 2, 3)},
         baseline="torch",
         ref="torch")
     
-    p.run(ncu=args.ncu)
+    p.run(ncu=args.ncu, csv=args.csv)

--- a/demo/new_profiling/lora_new.py
+++ b/demo/new_profiling/lora_new.py
@@ -7,12 +7,7 @@ from cdsl_fn_utils import compile_cutedsl
 from trt_utils import build_trt_runner
 from baselines.lora import LoraModule
 
-from c2.hl.nodes import Builder, ForLoop, PersistentForLoopSM90, ConstantExpr
-import c2.hl.user_nodes
-from c2.hl.util import DType
-import hlgraph.nodes as hlN
-from hel import nodes
-from hlgraph.rasterization_helper import PersistentRasterizationHelper
+from kernels.hel.lora import get_kernel as get_c2_kernel
 from compiler import compile_hel
 
 """
@@ -38,36 +33,6 @@ gemm = LoRASM90(
     is_persistent=False)
 
 
-def build_c2_lora(m, n, k):
-    """See compiler_2's python/kernels/hel/lora.py.
-    """
-    raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
-    builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
-    
-    gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
-    gB = builder.GlobalTensor['b', DType.bfloat16, (n, k)]()
-    gXA = builder.GlobalTensor['xa', DType.bfloat16, (m, LORA_DIM)]()
-    gLB = builder.GlobalTensor['lora_b', DType.bfloat16, (n, LORA_DIM)]()
-    gC = builder.GlobalTensor['c', DType.bfloat16, (m, n)]()
-
-    with builder.enter_scope(PersistentForLoopSM90('sched_idx', raster.total_tiles(), raster.total_blocks(), block_dim=raster.block_dim())) as sched_idx:
-        coords = builder.ScheduleFunction['sched_coord', *raster.layout()](sched_idx)
-        tm = builder.SliceCoord[0](coords)
-        tn = builder.SliceCoord[1](coords)
-        acc = builder.hel_Zeros['acc', C2_TILE_M, C2_TILE_N, DType.float32]()
-        with builder.enter_scope(ForLoop('k', 0, k // C2_TILE_K, 1)) as tk:
-            dA = builder.hel_Load['dA', C2_TILE_M, C2_TILE_K](gA, tm, tk)
-            dB = builder.hel_Load['dB', C2_TILE_N, C2_TILE_K](gB, tn, tk)
-            builder.hel_AccumulatingGemm(dA, dB, acc)
-        # the lora update is a single k step, so it sits outside the k loop
-        dxA = builder.hel_Load['dxA', C2_TILE_M, LORA_DIM](gXA, tm, ConstantExpr(0))
-        dlB = builder.hel_Load['dLB', C2_TILE_N, LORA_DIM](gLB, tn, ConstantExpr(0))
-        builder.hel_AccumulatingGemm(dxA, dlB, acc)
-        builder.hel_Store(acc, gC, tm, tn)
-
-    return builder
-
-
 if __name__ == "__main__":
     args = get_profiling_job_args()
     prob_args = LORA_NT_16.with_config(args.config)
@@ -85,7 +50,7 @@ if __name__ == "__main__":
         return o
     
     m, n, k = prob_args.arg('m', 'n', 'k')
-    c2_kernel = compile_hel(build_c2_lora(m, n, k), name=f'lora_{m}x{n}x{k}')
+    c2_kernel = compile_hel(get_c2_kernel(m, n, k, C2_TILE_M, C2_TILE_N, C2_TILE_K, LORA_DIM), name=f'lora_{m}x{n}x{k}')
 
     def c2_kernel_fn(a_: torch.Tensor, b_: torch.Tensor, lA_: torch.Tensor, lB_: torch.Tensor):
         o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')

--- a/demo/new_profiling/rmsnorm_linear_new.py
+++ b/demo/new_profiling/rmsnorm_linear_new.py
@@ -7,12 +7,7 @@ from trt_utils import build_trt_runner
 from baselines.rmsnorm_swiglu_trt import RMSNormLinearModule
 from triton.testing import do_bench
 
-from c2.hl.nodes import Builder, ForLoop, PersistentForLoopSM90
-import c2.hl.user_nodes
-from c2.hl.util import DType
-import hlgraph.nodes as hlN
-from hel import nodes
-from hlgraph.rasterization_helper import PersistentRasterizationHelper
+from kernels.hel.rmsnorm_linear import get_kernel as get_c2_kernel
 from compiler import compile_hel
 
 """
@@ -63,38 +58,6 @@ def get_cdsl_kernel(a, b, *args, **kwargs):
     )
 
 
-def build_c2_rmsnorm_linear(m, n, k, eps=EPS):
-    """See compiler_2's python/kernels/hel/rmsnorm_linear.py
-    """
-    raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
-    builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
-    gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
-    gB = builder.GlobalTensor['b', DType.bfloat16, (n, k)]()
-    gC = builder.GlobalTensor['c', DType.bfloat16, (m, n)]()
-
-    with builder.enter_scope(PersistentForLoopSM90('sched_idx', raster.total_tiles(), raster.total_blocks(), block_dim=raster.block_dim())) as sched_idx:
-        coords = builder.ScheduleFunction['sched_coord', *raster.layout()](sched_idx)
-        tm = builder.SliceCoord[0](coords)
-        tn = builder.SliceCoord[1](coords)
-        acc = builder.hel_Zeros['acc', C2_TILE_M, C2_TILE_N, DType.float32]()
-        sum_acc = builder.hel_Zeros['sum_acc', C2_TILE_M, 1, DType.float32]()
-
-        with builder.enter_scope(ForLoop('k', 0, k // C2_TILE_K, 1)) as tk:
-            dA = builder.hel_Load['dA', C2_TILE_M, C2_TILE_K](gA, tm, tk)
-            dB = builder.hel_Load['dB', C2_TILE_N, C2_TILE_K](gB, tn, tk)
-            builder.hel_AccumulatingGemm(dA, dB, acc)
-
-            dAsq = builder.hel_Elementwise['square'](dA)
-            builder.hel_RowsumAccumulating(dAsq, sum_acc)
-        s_div = builder.hel_Elementwise['div', k](sum_acc)
-        s_add = builder.hel_Elementwise['add', eps](s_div)
-        s_rsqrt = builder.hel_Elementwise['rsqrt'](s_add)
-        acc_scaled = builder.hel_RowBcastOp['mul'](acc, s_rsqrt)
-        builder.hel_Store(acc_scaled, gC, tm, tn)
-
-    return builder
-
-
 if __name__ == "__main__":
     args = get_profiling_job_args()
     prob_args = RMSNORM_LINEAR_ARGS_NT.with_config(args.config) # Get set of tensors defining the problem
@@ -111,7 +74,7 @@ if __name__ == "__main__":
     # NOTE TRT initializes eps in the object
     m, n, k = prob_args.arg('m', 'n', 'k')
     # NOTE c2 sets eps in the program
-    c2_kernel = compile_hel(build_c2_rmsnorm_linear(m, n, k), name=f'rmsnorm_linear_{m}x{n}x{k}')
+    c2_kernel = compile_hel(get_c2_kernel(m, n, k, C2_TILE_M, C2_TILE_N, C2_TILE_K), name=f'rmsnorm_linear_{m}x{n}x{k}')
 
     def c2_kernel_fn(a_: torch.Tensor, b_: torch.Tensor):
         o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')
@@ -128,7 +91,7 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "rmsnorm_lin",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner, 'max': torch_gemm, 'c2': c2_kernel_fn},
+        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner, 'c2': c2_kernel_fn, 'max': torch_gemm},
         args=prob_args,
         arg_mask={"torch": (0, 1, 3), "cutedsl": (0, 1, 3), "trt": (0, 1), 'max': (0, 1), 'c2': (0, 1)},
         baseline="torch",

--- a/demo/new_profiling/rmsnorm_linear_new.py
+++ b/demo/new_profiling/rmsnorm_linear_new.py
@@ -7,12 +7,22 @@ from trt_utils import build_trt_runner
 from baselines.rmsnorm_swiglu_trt import RMSNormLinearModule
 from triton.testing import do_bench
 
+from c2.hl.nodes import Builder, ForLoop, PersistentForLoopSM90
+import c2.hl.user_nodes
+from c2.hl.util import DType
+import hlgraph.nodes as hlN
+from hel import nodes
+from hlgraph.rasterization_helper import PersistentRasterizationHelper
+from compiler import compile_hel
+
 """
 RMSNorm + Linear
 """
 torch.manual_seed(18)
 
 EPS = 1e-5
+
+C2_TILE_M, C2_TILE_N, C2_TILE_K = 128, 256, 64
 
 @torch.compile
 def torch_kernel(a: torch.Tensor, b: torch.Tensor, eps: float=EPS):
@@ -53,6 +63,38 @@ def get_cdsl_kernel(a, b, *args, **kwargs):
     )
 
 
+def build_c2_rmsnorm_linear(m, n, k, eps=EPS):
+    """See compiler_2's python/kernels/hel/rmsnorm_linear.py
+    """
+    raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
+    builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
+    gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
+    gB = builder.GlobalTensor['b', DType.bfloat16, (n, k)]()
+    gC = builder.GlobalTensor['c', DType.bfloat16, (m, n)]()
+
+    with builder.enter_scope(PersistentForLoopSM90('sched_idx', raster.total_tiles(), raster.total_blocks(), block_dim=raster.block_dim())) as sched_idx:
+        coords = builder.ScheduleFunction['sched_coord', *raster.layout()](sched_idx)
+        tm = builder.SliceCoord[0](coords)
+        tn = builder.SliceCoord[1](coords)
+        acc = builder.hel_Zeros['acc', C2_TILE_M, C2_TILE_N, DType.float32]()
+        sum_acc = builder.hel_Zeros['sum_acc', C2_TILE_M, 1, DType.float32]()
+
+        with builder.enter_scope(ForLoop('k', 0, k // C2_TILE_K, 1)) as tk:
+            dA = builder.hel_Load['dA', C2_TILE_M, C2_TILE_K](gA, tm, tk)
+            dB = builder.hel_Load['dB', C2_TILE_N, C2_TILE_K](gB, tn, tk)
+            builder.hel_AccumulatingGemm(dA, dB, acc)
+
+            dAsq = builder.hel_Elementwise['square'](dA)
+            builder.hel_RowsumAccumulating(dAsq, sum_acc)
+        s_div = builder.hel_Elementwise['div', k](sum_acc)
+        s_add = builder.hel_Elementwise['add', eps](s_div)
+        s_rsqrt = builder.hel_Elementwise['rsqrt'](s_add)
+        acc_scaled = builder.hel_RowBcastOp['mul'](acc, s_rsqrt)
+        builder.hel_Store(acc_scaled, gC, tm, tn)
+
+    return builder
+
+
 if __name__ == "__main__":
     args = get_profiling_job_args()
     prob_args = RMSNORM_LINEAR_ARGS_NT.with_config(args.config) # Get set of tensors defining the problem
@@ -68,6 +110,14 @@ if __name__ == "__main__":
     
     # NOTE TRT initializes eps in the object
     m, n, k = prob_args.arg('m', 'n', 'k')
+    # NOTE c2 sets eps in the program
+    c2_kernel = compile_hel(build_c2_rmsnorm_linear(m, n, k), name=f'rmsnorm_linear_{m}x{n}x{k}')
+
+    def c2_kernel_fn(a_: torch.Tensor, b_: torch.Tensor):
+        o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')
+        c2_kernel(a_, b_, o)
+        return o
+
     trt_runner = build_trt_runner(
         module=RMSNormLinearModule(eps=EPS),
         example_inputs=prob_args.tensors((0, 1)),
@@ -78,10 +128,10 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "rmsnorm_lin",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner, 'max': torch_gemm},
+        kernels={"cutedsl": cdsl_kernel, "torch": torch_kernel, 'trt': trt_runner, 'max': torch_gemm, 'c2': c2_kernel_fn},
         args=prob_args,
-        arg_mask={"torch": (0, 1, 3), "cutedsl": (0, 1, 3), "trt": (0, 1), 'max': (0, 1)},
+        arg_mask={"torch": (0, 1, 3), "cutedsl": (0, 1, 3), "trt": (0, 1), 'max': (0, 1), 'c2': (0, 1)},
         baseline="torch",
         ref="torch")
     
-    p.run(ncu=args.ncu)
+    p.run(ncu=args.ncu, csv=args.csv)

--- a/demo/new_profiling/swiglu_new.py
+++ b/demo/new_profiling/swiglu_new.py
@@ -8,12 +8,7 @@ from cdsl_fn_utils import compile_cutedsl
 from trt_utils import build_trt_runner
 from baselines.rmsnorm_swiglu_trt import SwigluSeparateModule
 
-from c2.hl.nodes import Builder, ForLoop, PersistentForLoopSM90
-import c2.hl.user_nodes
-from c2.hl.util import DType
-import hlgraph.nodes as hlN
-from hel import nodes
-from hlgraph.rasterization_helper import PersistentRasterizationHelper
+from kernels.hel.swiglu import get_kernel as get_c2_kernel
 from compiler import compile_hel
 
 """
@@ -49,35 +44,6 @@ cdsl_swiglu = Swiglu3SM90(
 )
 
 
-def build_c2_swiglu(m, n, k):
-    """See compiler_2's python/kernels/hel/swiglu.py."""
-    raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
-    builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
-    gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
-    gB = builder.GlobalTensor['b', DType.bfloat16, (n, k)]()
-    gB1 = builder.GlobalTensor['b1', DType.bfloat16, (n, k)]()
-    gC = builder.GlobalTensor['c', DType.bfloat16, (m, n)]()
-
-    with builder.enter_scope(PersistentForLoopSM90('sched_idx', raster.total_tiles(), raster.total_blocks(), block_dim=raster.block_dim())) as sched_idx:
-        coords = builder.ScheduleFunction['sched_coord', *raster.layout()](sched_idx)
-        tm = builder.SliceCoord[0](coords)
-        tn = builder.SliceCoord[1](coords)
-        acc = builder.hel_Zeros['acc', C2_TILE_M, C2_TILE_N, DType.float32]()
-        acc1 = builder.hel_Zeros['acc1', C2_TILE_M, C2_TILE_N, DType.float32]()
-        
-        with builder.enter_scope(ForLoop('k', 0, k // C2_TILE_K, 1)) as tk:
-            dA = builder.hel_Load['dA', C2_TILE_M, C2_TILE_K](gA, tm, tk)
-            dB = builder.hel_Load['dB', C2_TILE_N, C2_TILE_K](gB, tn, tk)
-            dB1 = builder.hel_Load['dB1', C2_TILE_N, C2_TILE_K](gB1, tn, tk)
-            builder.hel_AccumulatingGemm(dA, dB, acc)
-            builder.hel_AccumulatingGemm(dA, dB1, acc1)
-        acc_silu = builder.hel_Elementwise['silu'](acc)
-        acc_final = builder.hel_Tilewise['mul'](acc_silu, acc1)
-        builder.hel_Store(acc_final, gC, tm, tn)
-
-    return builder
-
-
 if __name__ == "__main__":
     args = get_profiling_job_args()
     prob_args = SWIGLU_NT.with_config(args.config) # Get set of tensors defining the problem
@@ -91,7 +57,7 @@ if __name__ == "__main__":
         return o
     
     m, n, k = prob_args.arg('m', 'n', 'k')
-    c2_kernel = compile_hel(build_c2_swiglu(m, n, k), name=f'swiglu_{m}x{n}x{k}')
+    c2_kernel = compile_hel(get_c2_kernel(m, n, k, C2_TILE_M, C2_TILE_N, C2_TILE_K), name=f'swiglu_{m}x{n}x{k}')
 
     def c2_kernel_fn(a_: torch.Tensor, b_: torch.Tensor, b1_: torch.Tensor):
         o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')
@@ -110,7 +76,7 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "swiglu",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_swiglu, "tensorrt": trt_runner, "max": torch_gemm, "c2": c2_kernel_fn},
+        kernels={"cutedsl": cdsl_kernel, "torch": torch_swiglu, "tensorrt": trt_runner, "c2": c2_kernel_fn, "max": torch_gemm},
         args=prob_args,
         arg_mask={"torch": (0, 1, 2), "cutedsl": (0, 1, 2), "tensorrt": (0, 1, 2), "max": (0, 1, 2), "c2": (0, 1, 2)},
         baseline="torch",

--- a/demo/new_profiling/swiglu_new.py
+++ b/demo/new_profiling/swiglu_new.py
@@ -8,12 +8,22 @@ from cdsl_fn_utils import compile_cutedsl
 from trt_utils import build_trt_runner
 from baselines.rmsnorm_swiglu_trt import SwigluSeparateModule
 
+from c2.hl.nodes import Builder, ForLoop, PersistentForLoopSM90
+import c2.hl.user_nodes
+from c2.hl.util import DType
+import hlgraph.nodes as hlN
+from hel import nodes
+from hlgraph.rasterization_helper import PersistentRasterizationHelper
+from compiler import compile_hel
+
 """
 Profiles torch gemm vs cutedsl gemm
 
 Uses new profiling setup
 """
 torch.manual_seed(18)
+
+C2_TILE_M, C2_TILE_N, C2_TILE_K = 128, 128, 64
 
 # can't do torch.compile
 def torch_gemm(a: torch.Tensor, b: torch.Tensor, b1: torch.Tensor):
@@ -39,6 +49,35 @@ cdsl_swiglu = Swiglu3SM90(
 )
 
 
+def build_c2_swiglu(m, n, k):
+    """See compiler_2's python/kernels/hel/swiglu.py."""
+    raster = PersistentRasterizationHelper(m, n, C2_TILE_M, C2_TILE_N).with_block(8, 8)
+    builder = Builder(_p=hlN.HLProgram(raster.grid_size(), 256, raster.cluster_shape, tma_stages=3))
+    gA = builder.GlobalTensor['a', DType.bfloat16, (m, k)]()
+    gB = builder.GlobalTensor['b', DType.bfloat16, (n, k)]()
+    gB1 = builder.GlobalTensor['b1', DType.bfloat16, (n, k)]()
+    gC = builder.GlobalTensor['c', DType.bfloat16, (m, n)]()
+
+    with builder.enter_scope(PersistentForLoopSM90('sched_idx', raster.total_tiles(), raster.total_blocks(), block_dim=raster.block_dim())) as sched_idx:
+        coords = builder.ScheduleFunction['sched_coord', *raster.layout()](sched_idx)
+        tm = builder.SliceCoord[0](coords)
+        tn = builder.SliceCoord[1](coords)
+        acc = builder.hel_Zeros['acc', C2_TILE_M, C2_TILE_N, DType.float32]()
+        acc1 = builder.hel_Zeros['acc1', C2_TILE_M, C2_TILE_N, DType.float32]()
+        
+        with builder.enter_scope(ForLoop('k', 0, k // C2_TILE_K, 1)) as tk:
+            dA = builder.hel_Load['dA', C2_TILE_M, C2_TILE_K](gA, tm, tk)
+            dB = builder.hel_Load['dB', C2_TILE_N, C2_TILE_K](gB, tn, tk)
+            dB1 = builder.hel_Load['dB1', C2_TILE_N, C2_TILE_K](gB1, tn, tk)
+            builder.hel_AccumulatingGemm(dA, dB, acc)
+            builder.hel_AccumulatingGemm(dA, dB1, acc1)
+        acc_silu = builder.hel_Elementwise['silu'](acc)
+        acc_final = builder.hel_Tilewise['mul'](acc_silu, acc1)
+        builder.hel_Store(acc_final, gC, tm, tn)
+
+    return builder
+
+
 if __name__ == "__main__":
     args = get_profiling_job_args()
     prob_args = SWIGLU_NT.with_config(args.config) # Get set of tensors defining the problem
@@ -52,6 +91,13 @@ if __name__ == "__main__":
         return o
     
     m, n, k = prob_args.arg('m', 'n', 'k')
+    c2_kernel = compile_hel(build_c2_swiglu(m, n, k), name=f'swiglu_{m}x{n}x{k}')
+
+    def c2_kernel_fn(a_: torch.Tensor, b_: torch.Tensor, b1_: torch.Tensor):
+        o = torch.empty(a_.shape[0], b_.shape[0], dtype=torch.bfloat16, device='cuda')
+        c2_kernel(a_, b_, b1_, o)
+        return o
+
     trt_tensors = prob_args.tensors((0, 1, 2))
     trt_runner = build_trt_runner(
         module=SwigluSeparateModule(),
@@ -64,10 +110,10 @@ if __name__ == "__main__":
 
     p = ProfilingJob(
         "swiglu",
-        kernels={"cutedsl": cdsl_kernel, "torch": torch_swiglu, "tensorrt": trt_runner, "max": torch_gemm},
+        kernels={"cutedsl": cdsl_kernel, "torch": torch_swiglu, "tensorrt": trt_runner, "max": torch_gemm, "c2": c2_kernel_fn},
         args=prob_args,
-        arg_mask={"torch": (0, 1, 2), "cutedsl": (0, 1, 2), "tensorrt": (0, 1, 2), "max": (0, 1, 2)},
+        arg_mask={"torch": (0, 1, 2), "cutedsl": (0, 1, 2), "tensorrt": (0, 1, 2), "max": (0, 1, 2), "c2": (0, 1, 2)},
         baseline="torch",
         ref="torch")
     
-    p.run(ncu=args.ncu)
+    p.run(ncu=args.ncu, csv=args.csv)

--- a/python/profile_utils.py
+++ b/python/profile_utils.py
@@ -70,6 +70,20 @@ class ExperimentOutput:
         return ','.join(str(x) for x in lst)
 
 
+def write_csv_rows(rows, path=None):
+    """
+    Write csv rows to <path> or to stdout when no path is given
+
+    Every config runs in its own process so each will append to csv.
+    """
+    if path is None:
+        for r in rows:
+            print(r)
+        return
+    with open(path, 'a') as f:
+        f.write(''.join(f'{r}\n' for r in rows))
+
+
 # PROFILING METHODS
 def cuda_timings(func, warmup=10, bench=50):
     with torch.no_grad():
@@ -369,16 +383,15 @@ class ProfilingJob:
         for k in self.kernels:
             self.outputs[k].run_ncu(self.kernels[k], self.args[k])
     
-    def run(self, ncu=False):
+    def run(self, ncu=False, csv=None):
         if ncu:
             self._run_ncu()
         else:
             self._run()
-        self.output_results()
-    
-    def output_results(self):
-        for k in self.outputs:
-            print(ExperimentOutput.list_to_csv(self.outputs[k].values()))
+        self.output_results(csv)
+
+    def output_results(self, csv=None):
+        write_csv_rows([ExperimentOutput.list_to_csv(self.outputs[k].values()) for k in self.outputs], csv)
 
 def get_profiling_job_args(parse=True):
     """
@@ -388,6 +401,7 @@ def get_profiling_job_args(parse=True):
     parser.add_argument("config", type=int, help="the config number")
 
     parser.add_argument("--ncu", action='store_true')
+    parser.add_argument("--csv", default=None, help="append the results to csv file instead of stdout")
     if parse:
         args = parser.parse_args()
         return args

--- a/run_scripts/profile_gemm.sh
+++ b/run_scripts/profile_gemm.sh
@@ -1,9 +1,22 @@
+# Profiles compiler_2 vs CuteDSL vs Torch gemm over the GEMM_SHAPES configs
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. & pwd)"
 
-python3 $DIR/demo/gen_header.py ExperimentOutput
+# Default CSV file, comment out to specify where to redirect stdout for unstructured output
+CSV="${1:-results/gemm_$(date +%Y%m%d_%H%M%S).csv}"
 
-for i in $(seq 0 10) 
+# Write the header into CSV, overwrites the files
+# or to stdout when CSV is not set
+if [ -n "$CSV" ]; then
+    mkdir -p "$(dirname "$CSV")"
+    echo writing csv to ${CSV:-"the run script default"}
+    python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
+else
+    python3 $DIR/demo/gen_header.py ExperimentOutput
+fi
+
+for i in $(seq 0 10)
 do
-    python3 $DIR/demo/new_profiling/gemm_new.py $i
+    python3 $DIR/demo/new_profiling/gemm_new.py $i ${CSV:+--csv "$CSV"}
     sleep 3
 done

--- a/run_scripts/profile_gemm.sh
+++ b/run_scripts/profile_gemm.sh
@@ -1,22 +1,17 @@
 # Profiles compiler_2 vs CuteDSL vs Torch gemm over the GEMM_SHAPES configs
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. & pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Default CSV file, comment out to specify where to redirect stdout for unstructured output
+# Default CSV file, pass a path as the first argument to override
 CSV="${1:-results/gemm_$(date +%Y%m%d_%H%M%S).csv}"
 
-# Write the header into CSV, overwrites the files
-# or to stdout when CSV is not set
-if [ -n "$CSV" ]; then
-    mkdir -p "$(dirname "$CSV")"
-    echo writing csv to ${CSV:-"the run script default"}
-    python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
-else
-    python3 $DIR/demo/gen_header.py ExperimentOutput
-fi
+# Write the header into CSV, overwrites the file
+mkdir -p "$(dirname "$CSV")"
+echo writing csv to $CSV
+python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
 
 for i in $(seq 0 10)
 do
-    python3 $DIR/demo/new_profiling/gemm_new.py $i ${CSV:+--csv "$CSV"}
+    python3 $DIR/demo/new_profiling/gemm_new.py $i --csv "$CSV"
     sleep 3
 done

--- a/run_scripts/profile_gemm.sh
+++ b/run_scripts/profile_gemm.sh
@@ -1,11 +1,9 @@
-# Profiles CuteDSL vs Torch vs cuBLAS gemm for available GEMM shapes
-# uses m128n256 as the tile size for torch
-
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. & pwd)"
 
 python3 $DIR/demo/gen_header.py ExperimentOutput
 
-while read -r m n k; do
-    python3 $DIR/demo/gemm.py "$m" "$n" "$k" --to_csv
-    sleep 2
-done < $DIR/res/cdsl_gemm_shapes_m128n256.txt
+for i in $(seq 0 10) 
+do
+    python3 $DIR/demo/new_profiling/gemm_new.py $i
+    sleep 3
+done

--- a/run_scripts/profile_lora.sh
+++ b/run_scripts/profile_lora.sh
@@ -1,9 +1,9 @@
-# Profiles compiler_2 vs CuteDSL vs Torch vs TRT rmsnorm+linear over the GEMM_SHAPES configs
+# Profiles compiler_2 vs CuteDSL vs Torch vs TRT lora over the GEMM_SHAPES configs
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. & pwd)"
 
 # Default CSV file, comment out to specify where to redirect stdout for unstructured output
-CSV="${1:-results/rmsnorm_linear_$(date +%Y%m%d_%H%M%S).csv}"
+CSV="${1:-results/lora_$(date +%Y%m%d_%H%M%S).csv}"
 
 # Write the header into CSV, overwrites the files
 # or to stdout when CSV is not set
@@ -17,6 +17,6 @@ fi
 
 for i in $(seq 0 10)
 do
-    python3 $DIR/demo/new_profiling/rmsnorm_linear_new.py $i ${CSV:+--csv "$CSV"}
+    python3 $DIR/demo/new_profiling/lora_new.py $i ${CSV:+--csv "$CSV"}
     sleep 3
 done

--- a/run_scripts/profile_lora.sh
+++ b/run_scripts/profile_lora.sh
@@ -1,22 +1,17 @@
 # Profiles compiler_2 vs CuteDSL vs Torch vs TRT lora over the GEMM_SHAPES configs
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. & pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Default CSV file, comment out to specify where to redirect stdout for unstructured output
+# Default CSV file, pass a path as the first argument to override
 CSV="${1:-results/lora_$(date +%Y%m%d_%H%M%S).csv}"
 
-# Write the header into CSV, overwrites the files
-# or to stdout when CSV is not set
-if [ -n "$CSV" ]; then
-    mkdir -p "$(dirname "$CSV")"
-    echo writing csv to ${CSV:-"the run script default"}
-    python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
-else
-    python3 $DIR/demo/gen_header.py ExperimentOutput
-fi
+# Write the header into CSV, overwrites the file
+mkdir -p "$(dirname "$CSV")"
+echo writing csv to $CSV
+python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
 
 for i in $(seq 0 10)
 do
-    python3 $DIR/demo/new_profiling/lora_new.py $i ${CSV:+--csv "$CSV"}
+    python3 $DIR/demo/new_profiling/lora_new.py $i --csv "$CSV"
     sleep 3
 done

--- a/run_scripts/profile_rmsnorm_linear.sh
+++ b/run_scripts/profile_rmsnorm_linear.sh
@@ -1,22 +1,17 @@
 # Profiles compiler_2 vs CuteDSL vs Torch vs TRT rmsnorm+linear over the GEMM_SHAPES configs
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. & pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Default CSV file, comment out to specify where to redirect stdout for unstructured output
+# Default CSV file, pass a path as the first argument to override
 CSV="${1:-results/rmsnorm_linear_$(date +%Y%m%d_%H%M%S).csv}"
 
-# Write the header into CSV, overwrites the files
-# or to stdout when CSV is not set
-if [ -n "$CSV" ]; then
-    mkdir -p "$(dirname "$CSV")"
-    echo writing csv to ${CSV:-"the run script default"}
-    python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
-else
-    python3 $DIR/demo/gen_header.py ExperimentOutput
-fi
+# Write the header into CSV, overwrites the file
+mkdir -p "$(dirname "$CSV")"
+echo writing csv to $CSV
+python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
 
 for i in $(seq 0 10)
 do
-    python3 $DIR/demo/new_profiling/rmsnorm_linear_new.py $i ${CSV:+--csv "$CSV"}
+    python3 $DIR/demo/new_profiling/rmsnorm_linear_new.py $i --csv "$CSV"
     sleep 3
 done

--- a/run_scripts/profile_swiglu.sh
+++ b/run_scripts/profile_swiglu.sh
@@ -1,11 +1,22 @@
-# Output torch vs cublas timings for SwiGLU shapes
-# reuse rmsnorm shapes for this
+# Profiles compiler_2 vs CuteDSL vs Torch vs TRT swiglu over the GEMM_SHAPES configs
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. & pwd)"
 
-python3 $DIR/demo/gen_header.py ExperimentOutput
+# Default CSV file, comment out to specify where to redirect stdout for unstructured output
+CSV="${1:-results/swiglu_$(date +%Y%m%d_%H%M%S).csv}"
 
-while read -r m n k; do
-    python3 $DIR/demo/swiglu.py "$m" "$n" "$k" --to_csv
-    sleep 4
-done < $DIR/res/cdsl_rmsnorm_shapes_m128n256.txt
+# Write the header into CSV, overwrites the files
+# or to stdout when CSV is not set
+if [ -n "$CSV" ]; then
+    mkdir -p "$(dirname "$CSV")"
+    echo writing csv to ${CSV:-"the run script default"}
+    python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
+else
+    python3 $DIR/demo/gen_header.py ExperimentOutput
+fi
+
+for i in $(seq 0 10)
+do
+    python3 $DIR/demo/new_profiling/swiglu_new.py $i ${CSV:+--csv "$CSV"}
+    sleep 3
+done

--- a/run_scripts/profile_swiglu.sh
+++ b/run_scripts/profile_swiglu.sh
@@ -1,22 +1,17 @@
 # Profiles compiler_2 vs CuteDSL vs Torch vs TRT swiglu over the GEMM_SHAPES configs
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. & pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Default CSV file, comment out to specify where to redirect stdout for unstructured output
+# Default CSV file, pass a path as the first argument to override
 CSV="${1:-results/swiglu_$(date +%Y%m%d_%H%M%S).csv}"
 
-# Write the header into CSV, overwrites the files
-# or to stdout when CSV is not set
-if [ -n "$CSV" ]; then
-    mkdir -p "$(dirname "$CSV")"
-    echo writing csv to ${CSV:-"the run script default"}
-    python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
-else
-    python3 $DIR/demo/gen_header.py ExperimentOutput
-fi
+# Write the header into CSV, overwrites the file
+mkdir -p "$(dirname "$CSV")"
+echo writing csv to $CSV
+python3 $DIR/demo/gen_header.py ExperimentOutput > "$CSV"
 
 for i in $(seq 0 10)
 do
-    python3 $DIR/demo/new_profiling/swiglu_new.py $i ${CSV:+--csv "$CSV"}
+    python3 $DIR/demo/new_profiling/swiglu_new.py $i --csv "$CSV"
     sleep 3
 done

--- a/slurm_profile.sh
+++ b/slurm_profile.sh
@@ -7,10 +7,15 @@
 #SBATCH --output=slurm_outputs/KernelsProfile_%j.out
 #SBATCH --error=slurm_outputs/KernelsProfile_%j.err
 
-# e.g. sbatch --export=ALL,CONTAINER="kernel_bench_apptainer.sif",SCRIPT="run_scripts/profile_rmsnorm_linear.sh",OUTPUT="profile_data.csv" slurm_profile.sh
+# e.g. sbatch --export=ALL,CONTAINER="kernel_bench_apptainer.sif",SCRIPT="run_scripts/profile_gemm.sh",CSV="results/gemm.csv" slurm_profile.sh
+# CSV is passed to the run script as its first argument, leave it unset to use the run script's default
+# OUTPUT is an optional non-csv output. In case CSV is specified it will take the rest of the stdout
+# leave it unset to let stdout go to the default slurm .out file
 echo using container $CONTAINER
 echo using script $SCRIPT
+echo writing csv to ${CSV:-"the run script default"}
 module load apptainer
 
+# Redirect conditional on OUTPUT specified
 apptainer exec --nv \
-  $CONTAINER bash -c "source ./add_path.sh && $SCRIPT > $OUTPUT"
+  $CONTAINER bash -c "source ./add_path.sh && $SCRIPT $CSV ${OUTPUT:+> $OUTPUT}"

--- a/slurm_profile.sh
+++ b/slurm_profile.sh
@@ -9,13 +9,10 @@
 
 # e.g. sbatch --export=ALL,CONTAINER="kernel_bench_apptainer.sif",SCRIPT="run_scripts/profile_gemm.sh",CSV="results/gemm.csv" slurm_profile.sh
 # CSV is passed to the run script as its first argument, leave it unset to use the run script's default
-# OUTPUT is an optional non-csv output. In case CSV is specified it will take the rest of the stdout
-# leave it unset to let stdout go to the default slurm .out file
 echo using container $CONTAINER
 echo using script $SCRIPT
 echo writing csv to ${CSV:-"the run script default"}
 module load apptainer
 
-# Redirect conditional on OUTPUT specified
 apptainer exec --nv \
-  $CONTAINER bash -c "source ./add_path.sh && $SCRIPT $CSV ${OUTPUT:+> $OUTPUT}"
+  $CONTAINER bash -c "source ./add_path.sh && $SCRIPT $CSV"


### PR DESCRIPTION
Adding C2 as submodule and profiling it

To profile C2:

`git submodule update --init --recursive`

To update c2 to the correct branch:
`git submodule update --remote third_party/compiler_2`

`sbatch --export=ALL,CONTAINER="kernel_bench_apptainer.sif",SCRIPT="run_scripts/profile_gemm.sh",OUTPUT="gemm_c2.csv" slurm_profile.sh`


Reason it is a draft:
- All the stdout from C2 ends up in the csv file now. Either remove that in C2 or redirect stdout away from csv file. The latter would anyways help with warnings from different frameworks showing up in the csv file.